### PR TITLE
Show participant overlays by default on recordings

### DIFF
--- a/web/src/GridPage.tsx
+++ b/web/src/GridPage.tsx
@@ -116,6 +116,8 @@ const renderStage: React.FC<StageProps> = ({ roomState }: StageProps) => {
           width="100%"
           height="100%"
           adaptiveVideo
+          showOverlay
+          displayName={participant.identity}
         />
       ))}
       {audioRenderers}

--- a/web/src/SpeakerPage.tsx
+++ b/web/src/SpeakerPage.tsx
@@ -76,6 +76,8 @@ const renderStage: React.FC<StageProps> = ({ roomState }: StageProps) => {
           width="100%"
           height="100%"
           orientation="landscape"
+          displayName={remoteParticipants[0].identity}
+          showOverlay
         />
         {audioRenderers}
       </>
@@ -99,6 +101,8 @@ const renderStage: React.FC<StageProps> = ({ roomState }: StageProps) => {
         height="100%"
         orientation="landscape"
         quality={VideoQuality.HIGH}
+        displayName={remoteParticipants[0].identity}
+        showOverlay
       />
     );
   }
@@ -115,6 +119,8 @@ const renderStage: React.FC<StageProps> = ({ roomState }: StageProps) => {
             height="100%"
             orientation="landscape"
             adaptiveVideo
+            displayName={participant.identity}
+            showOverlay
           />
         ))}
       </div>


### PR DESCRIPTION
The participant overlays in livekit-react only appear when there's a mouseOver on the displays - and then you can see the participant info.  On recordings, there's no mouse events, so there's no participant info in the recording.

With this change, participant overlays are "always on" during the recording; on review, one can see the participant name, who's muted, etc.