### PR TITLE
Change rtmpsink sync to rtmp2sink in gstream pipeline

### DIFF
--- a/pkg/pipeline/output.go
+++ b/pkg/pipeline/output.go
@@ -109,7 +109,7 @@ func createRtmpOut(url string) (*RtmpOut, error) {
 	}
 	queue.SetArg("leaky", "downstream")
 
-	sink, err := gst.NewElementWithName("rtmpsink", fmt.Sprintf("sink_%s", id))
+	sink, err := gst.NewElementWithName("rtmp2sink", fmt.Sprintf("sink_%s", id))
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -115,7 +115,7 @@ func testRecording(t *testing.T,
 }
 
 func testStream(t *testing.T, conf *config.Config) {
-	rtmpUrl := "rtmp://localhost:1935/stream1"
+	rtmpUrl := "rtmp://localhost:1935/live/stream1"
 	req := &livekit.StartRecordingRequest{
 		Input: &livekit.StartRecordingRequest_Url{
 			Url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
@@ -146,7 +146,7 @@ func testStream(t *testing.T, conf *config.Config) {
 	verifyStream(t, req, rtmpUrl)
 
 	// add another, check both
-	rtmpUrl2 := "rtmp://localhost:1935/stream2"
+	rtmpUrl2 := "rtmp://localhost:1935/live/stream2"
 	require.NoError(t, rec.AddOutput(rtmpUrl2))
 	verifyStream(t, req, rtmpUrl, rtmpUrl2)
 


### PR DESCRIPTION
Hi!

This rtmpsink  is not able to negotiate correctly tls sockets. Seems related to library for [ssl](https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/1342)

This has been tested both with Amazon IVS and Twich (non TLS sockets)

slack discussion
https://livekit-users.slack.com/archives/C025KM0S1CK/p1646400669233219